### PR TITLE
Solve Compilation Error

### DIFF
--- a/freelearn/src/main/java/unifor/devweb/project/freelearn/mapper/CourseMapper.java
+++ b/freelearn/src/main/java/unifor/devweb/project/freelearn/mapper/CourseMapper.java
@@ -3,8 +3,15 @@ package unifor.devweb.project.freelearn.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+import unifor.devweb.project.freelearn.domain.AbstractEntity;
 import unifor.devweb.project.freelearn.domain.dto.CourseDTO;
 import unifor.devweb.project.freelearn.domain.entities.Course;
+import unifor.devweb.project.freelearn.domain.entities.CourseCategory;
+import unifor.devweb.project.freelearn.domain.entities.Student;
+import unifor.devweb.project.freelearn.domain.entities.Teacher;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper
 public interface CourseMapper {
@@ -20,4 +27,51 @@ public interface CourseMapper {
     @Mapping(source = "enrolledStudentIds", target = "enrolledStudents")
     @Mapping(source = "teacherIds", target = "instructors")
     Course courseDTOToCourse(CourseDTO courseDTO);
+
+    default List<Long> mapCourseCategoryIds(List<CourseCategory> categories) {
+        return this.entityIdMapper(categories);
+    }
+
+    default List<Long> mapEnrolledStudentIds(List<Student> students) {
+        return this.entityIdMapper(students);
+    }
+
+    default List<Long> mapTeacherIds(List<Teacher> teachers) {
+        return this.entityIdMapper(teachers);
+    }
+
+    default List<CourseCategory> mapCourseCategoryIdsToCourse(List<Long> categories) {
+        return this.fromIdMapper(categories, CourseCategory.class);
+    }
+
+    default List<Student> mapEnrolledStudentIdsToStudent(List<Long> students) {
+        return this.fromIdMapper(students, Student.class);
+    }
+
+    default List<Teacher> mapTeacherIdsToTeacher(List<Long> teachers) {
+        return this.fromIdMapper(teachers, Teacher.class);
+    }
+
+    default <E extends AbstractEntity> List<Long> entityIdMapper(List<E> entities) {
+        return entities.stream()
+                .map((AbstractEntity::getId))
+                .collect(Collectors.toList());
+    }
+
+    default <E extends AbstractEntity> List<E> fromIdMapper(List<Long> idEntities, Class<E> clazz) {
+        return idEntities.stream()
+                .map(id -> {
+                    try {
+                        var classConstructor = clazz.getConstructor();
+                        var objInstance = classConstructor.newInstance();
+
+                        objInstance.setId(id);
+
+                        return objInstance;
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/freelearn/src/main/java/unifor/devweb/project/freelearn/services/CourseService.java
+++ b/freelearn/src/main/java/unifor/devweb/project/freelearn/services/CourseService.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 public class CourseService {
 
     private final CourseRepository courseRepository;
-    private final CourseMapper courseMapper;
+    private final CourseMapper courseMapper = CourseMapper.INSTANCE;
 
     public Page<CourseDTO> listAll(Pageable pageable) {
         return courseRepository.findAll(pageable)


### PR DESCRIPTION
- This PR aims to solve the compilation error when trying to incorrectly use Mapper from MapStruct

As MapStruct can't realize how to convert complex objects, i.e Long -> Object, neither Object -> Long, we had to have these mappers configured in our @Mapper interface. 
